### PR TITLE
[bug/desktop] App goes down when typing "return (enter)" key in inputting password to send assets

### DIFF
--- a/src/renderer/components/Maintenance.vue
+++ b/src/renderer/components/Maintenance.vue
@@ -11,6 +11,7 @@
 <script>
 export default {
   mounted () {
+    this.$store.dispatch('app/setLoading', false)
     this.$store.dispatch('app/setShowDrawer', false)
   }
 }

--- a/src/renderer/components/Send.vue
+++ b/src/renderer/components/Send.vue
@@ -117,6 +117,7 @@
                 :rules="passwordRule"
                 v-model="password"
                 type="password"
+                @keypress.13="submit()"
                 />
               </v-form>
             </div>


### PR DESCRIPTION
- prevent app goes down when press enter key for inputting password send assets.