### PR TITLE
[bug/desktop] App goes down when typing "return (enter)" key in inputting password to send assets

### DIFF
--- a/src/renderer/components/Send.vue
+++ b/src/renderer/components/Send.vue
@@ -110,7 +110,7 @@
           <v-card>
             <v-card-text class="dialog-wrap" v-html="this.dialogDesc"></v-card-text>
             <div v-if="requirePasswordOnSend === true">
-              <v-form>
+              <div>
                 <v-text-field
                 style="width: 248px; margin-left: 16px; margin-right: 16px"
                 :label="$t('send.password')"
@@ -119,7 +119,7 @@
                 type="password"
                 @keypress.13="submit()"
                 />
-              </v-form>
+              </div>
             </div>
             <v-card-actions>
               <v-spacer></v-spacer>


### PR DESCRIPTION
- prevent app goes down after click enter on inputting password